### PR TITLE
Improve templateing by moving boilerplate logic into block

### DIFF
--- a/src/app/Block/File.php
+++ b/src/app/Block/File.php
@@ -7,6 +7,12 @@ class File extends DataObject
 
     private $fileName;
 
+    /**
+     * File constructor.
+     *
+     * @param array $fileName
+     * @param array $data
+     */
     public function __construct(
         $fileName,
         $data = []
@@ -41,7 +47,7 @@ class File extends DataObject
      *
      * @return string
      */
-    public function namespace_module($isLower = true)
+    public function namespace_module($isLower = true) : string
     {
         $namespaceModule = $this->getData('namespace').'_'.$this->getData('module');
         if($isLower) {
@@ -50,4 +56,44 @@ class File extends DataObject
 
         return $namespaceModule;
     }
+
+    public function NamespaceModule() : string
+    {
+        return  $this->getData('namespace') . '\\' . $this->getData('module');
+    }
+
+    /**
+     * Get the table name
+     *
+     * @return string
+     */
+    public function table_name() : string
+    {
+        if ($this->getData('table_name')) {
+            return $this->getData('table_name');
+        }
+
+        if ($this->getData('class_name')) {
+            return $this->namespace_module() . '_' . strtolower($this->getData('class_name'));
+        }
+
+        return $this->namespace_module();
+    }
+
+    /**
+     * Get the namespace module name.
+     *
+     * @return string
+     */
+    public function namespace_module_frontname_action() : string
+    {
+        return $this->namespace_module().strtolower('_' . $this->getData('front_name') . '_' . $this->getData('action_name'));
+    }
+
+    public function template_name() : string
+    {
+        return $this->namespace_module(false) . '::' . strtolower($this->getData('front_name') . '/' . $this->getData('action_name')) . '.phtml';
+    }
+
+
 }

--- a/src/templates/src/Block/Adminhtml/Template.phtml
+++ b/src/templates/src/Block/Adminhtml/Template.phtml
@@ -4,7 +4,7 @@
 <?php echo '<?php' ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Block\Adminhtml;
+namespace <?php echo $block->NamespaceModule() ?>\Block\Adminhtml;
 
 class <?php echo $block->getData('block_name') ?> extends \Magento\Backend\Block\Template
 {

--- a/src/templates/src/Block/Template.phtml
+++ b/src/templates/src/Block/Template.phtml
@@ -4,7 +4,7 @@
 <?php echo '<?php' ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Block;
+namespace <?php echo $block->NamespaceModule() ?>\Block;
 
 class <?php echo $block->getData('block_name') ?> extends \Magento\Framework\View\Element\Template
 {

--- a/src/templates/src/Controller/Adminhtml/IndexController.phtml
+++ b/src/templates/src/Controller/Adminhtml/IndexController.phtml
@@ -4,7 +4,7 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Controller\Adminhtml\<?php echo $block->getData('front_name') ?>;
+namespace <?php echo $block->NamespaceModule() ?>\Controller\Adminhtml\<?php echo $block->getData('front_name') ?>;
 
 use Magento\Backend\App\Action as BackendAction;
 use Magento\Backend\App\Action\Context;

--- a/src/templates/src/Controller/IndexController.phtml
+++ b/src/templates/src/Controller/IndexController.phtml
@@ -4,7 +4,7 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Controller\<?php echo $block->getData('front_name') ?>;
+namespace <?php echo $block->NamespaceModule() ?>\Controller\<?php echo $block->getData('front_name') ?>;
 
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;

--- a/src/templates/src/Model/Model.phtml
+++ b/src/templates/src/Model/Model.phtml
@@ -4,7 +4,7 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Model;
+namespace <?php echo $block->NamespaceModule() ?>\Model;
 
 /**
  * Class <?php echo $block->getData('class_name') ?>
@@ -34,7 +34,7 @@ class <?php echo $block->getData('class_name') ?> extends \Magento\Framework\Mod
      */
     protected function _construct()
     {
-        $this->_init('<?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?>');
+        $this->_init('<?php echo $block->NamespaceModule() ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?>');
     }
 
 <?php endif; ?>

--- a/src/templates/src/Model/ResourceModel/Model.phtml
+++ b/src/templates/src/Model/ResourceModel/Model.phtml
@@ -4,13 +4,13 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace'); ?>\Model\ResourceModel;
+namespace <?php echo $block->NamespaceModule(); ?>\Model\ResourceModel;
 
 /**
  * Class <?php echo $block->getData('class_name'); ?>
 
  *
- * @package <?php echo $block->getData('namespace'); ?>\Model\ResourceModel
+ * @package <?php echo $block->NamespaceModule(); ?>\Model\ResourceModel
  */
 class <?php echo $block->getData('class_name'); ?> extends \Magento\Framework\Model\AbstractModel
 {
@@ -21,7 +21,7 @@ class <?php echo $block->getData('class_name'); ?> extends \Magento\Framework\Mo
      */
     protected function _construct()
     {
-        $this->_init('<?php echo $block->namespace_module(); ?>', 'entity_id');
+        $this->_init('<?php echo $block->table_name() ?>', 'entity_id');
     }
 
 }

--- a/src/templates/src/Model/ResourceModel/Model/Collection.phtml
+++ b/src/templates/src/Model/ResourceModel/Model/Collection.phtml
@@ -4,14 +4,14 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?>;
+namespace <?php echo $block->NamespaceModule() ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?>;
 
 /**
  * Class Collection
  *
- * @method <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?> _getResource()
+ * @method <?php echo $block->NamespaceModule() ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?> _getResource()
  *
- * @package <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?>
+ * @package <?php echo $block->NamespaceModule() ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?>
 
  */
 class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
@@ -29,7 +29,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      */
     protected function _construct()
     {
-        $this->_init('<?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Model\<?php echo $block->getData('class_name') ?>', '<?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?>');
+        $this->_init('<?php echo $block->NamespaceModule() ?>\Model\<?php echo $block->getData('class_name') ?>', '<?php echo $block->NamespaceModule() ?>\Model\ResourceModel\<?php echo $block->getData('class_name') ?>');
 
         return $this;
     }

--- a/src/templates/src/Observer/Observer.phtml
+++ b/src/templates/src/Observer/Observer.phtml
@@ -4,16 +4,15 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Observer;
+namespace <?php echo $block->NamespaceModule() ?>\Observer;
 
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Event\Observer;
 use Magento\Framework\View\LayoutInterface;
 
 /**
  * Class <?php echo $block->getData('class_name') ?>
  *
- * @package <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Observer
+ * @package <?php echo $block->NamespaceModule() ?>\Observer
  */
 class <?php echo $block->getData('class_name') ?> implements ObserverInterface
 {
@@ -26,7 +25,7 @@ class <?php echo $block->getData('class_name') ?> implements ObserverInterface
      *
      * @return void
      */
-    public function execute(Observer $observer)
+    public function execute(\Magento\Framework\Event\Observer $observer)
     {
         //TODO: Perform Observer logic
     }

--- a/src/templates/src/Setup/InstallSchema.php
+++ b/src/templates/src/Setup/InstallSchema.php
@@ -1,0 +1,45 @@
+<?php
+/** @var Brideo\Magento2Scaffolding\Block\File $block */
+echo '<?php'
+?>
+
+
+namespace <?php echo $block->NamespaceModule() ?>\Setup;
+
+use Magento\Framework\Setup\InstallSchemaInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\DB\Ddl\Table;
+
+class InstallSchema implements InstallSchemaInterface
+{
+    /**
+     * Installs DB schema for a module
+     *
+     * @param SchemaSetupInterface $setup
+     * @param ModuleContextInterface $context
+     *
+     * @return void
+     */
+    public function install(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $installer = $setup;
+
+        $installer->startSetup();
+
+        $table = $installer->getConnection()
+            ->newTable($installer->getTable(<?php echo $block->table_name() ?>))
+            ->addColumn(
+                'entity_id',
+                Table::TYPE_SMALLINT,
+                null,
+                ['identity' => true, 'nullable' => false, 'primary' => true],
+                'Entity ID'
+            );
+
+        $installer->getConnection()->createTable($table);
+
+        $installer->endSetup();
+    }
+
+}

--- a/src/templates/src/Test/Controller/Adminhtml/IndexControllerTest.phtml
+++ b/src/templates/src/Test/Controller/Adminhtml/IndexControllerTest.phtml
@@ -4,7 +4,7 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Test\Unit\Controller\Adminhtml\<?php echo $block->getData('front_name') ?>;
+namespace <?php echo $block->NamespaceModule() ?>\Test\Unit\Controller\Adminhtml\<?php echo $block->getData('front_name') ?>;
 
 use PHPUnit_Framework_TestCase;
 
@@ -12,7 +12,7 @@ class <?php echo $block->getData('action_name') ?>Test extends PHPUnit_Framework
 {
 
     /**
-     * @var \<?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Controller\Adminhtml\<?php echo $block->getData('front_name') ?>\<?php echo $block->getData('action_name') ?>;
+     * @var \<?php echo $block->NamespaceModule() ?>\Controller\Adminhtml\<?php echo $block->getData('front_name') ?>\<?php echo $block->getData('action_name') ?>;
      */
     protected $controller;
 
@@ -36,7 +36,7 @@ class <?php echo $block->getData('action_name') ?>Test extends PHPUnit_Framework
 
         /** @var \Magento\Backend\App\Action\Context $context */
         /** @var \Magento\Framework\View\Result\PageFactory $pageFactory */
-        $this->controller = new \<?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Controller\Adminhtml\<?php echo $block->getData('front_name') ?>\<?php echo $block->getData('action_name') ?>($context, $pageFactory);
+        $this->controller = new \<?php echo $block->NamespaceModule() ?>\Controller\Adminhtml\<?php echo $block->getData('front_name') ?>\<?php echo $block->getData('action_name') ?>($context, $pageFactory);
     }
 
     protected function tearDown()

--- a/src/templates/src/Test/Controller/IndexControllerTest.phtml
+++ b/src/templates/src/Test/Controller/IndexControllerTest.phtml
@@ -4,7 +4,7 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Test\Unit\Controller\<?php echo $block->getData('front_name') ?>;
+namespace <?php echo $block->NamespaceModule() ?>\Test\Unit\Controller\<?php echo $block->getData('front_name') ?>;
 
 use PHPUnit_Framework_TestCase;
 
@@ -12,7 +12,7 @@ class <?php echo $block->getData('action_name') ?>Test extends PHPUnit_Framework
 {
 
     /**
-     * @var  \<?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Controller\<?php echo $block->getData('front_name') ?>\<?php echo $block->getData('action_name') ?>;
+     * @var  \<?php echo $block->NamespaceModule() ?>\Controller\<?php echo $block->getData('front_name') ?>\<?php echo $block->getData('action_name') ?>;
      */
     protected $controller;
 
@@ -36,7 +36,7 @@ class <?php echo $block->getData('action_name') ?>Test extends PHPUnit_Framework
 
         /** @var \Magento\Framework\App\Action\Context $context */
         /** @var \Magento\Framework\View\Result\PageFactory $pageFactory */
-        $this->controller = new \<?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Controller\<?php echo $block->getData('front_name') ?>\<?php echo $block->getData('action_name') ?>($context, $pageFactory);
+        $this->controller = new \<?php echo $block->NamespaceModule() ?>\Controller\<?php echo $block->getData('front_name') ?>\<?php echo $block->getData('action_name') ?>($context, $pageFactory);
     }
 
     protected function tearDown()

--- a/src/templates/src/Test/Unit/ModuleTest.phtml
+++ b/src/templates/src/Test/Unit/ModuleTest.phtml
@@ -4,7 +4,7 @@ echo '<?php'
 ?>
 
 
-namespace <?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Test\Unit;
+namespace <?php echo $block->NamespaceModule() ?>\Test\Unit;
 
 use PHPUnit_Framework_TestCase;
 

--- a/src/templates/src/etc/acl.phtml
+++ b/src/templates/src/etc/acl.phtml
@@ -5,7 +5,7 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::content">
-                    <resource id="<?php echo $block->getData('namespace') ?>_<?php echo $block->getData('module') ?>::<?php echo strtolower($block->getData('front_name') .'_'. $block->getData('action_name')) ?>" title="<?php echo $block->getData('namespace') ?> <?php echo $block->getData('module') ?> <?php echo $block->getData('front_name') ?> <?php echo $block->getData('action_name') ?>" sortOrder="10"/>
+                    <resource id="<?php echo $block->namespace_module(false) ?>::<?php echo strtolower($block->getData('front_name') .'_'. $block->getData('action_name')) ?>" title="<?php echo $block->namespace_module(false) ?> <?php echo $block->getData('front_name') ?> <?php echo $block->getData('action_name') ?>" sortOrder="10"/>
                 </resource>
             </resource>
         </resources>

--- a/src/templates/src/etc/adminhtml/routes.phtml
+++ b/src/templates/src/etc/adminhtml/routes.phtml
@@ -2,8 +2,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="admin">
-        <route id="<?php echo strtolower($block->getData('namespace') .'_'. $block->getData('module')) ?>" frontName="<?php echo strtolower($block->getData('namespace') .'_'. $block->getData('module')) ?>">
-            <module name="<?php echo $block->getData('namespace') ?>_<?php echo $block->getData('module') ?>" before="Magento_Backend" />
+        <route id="<?php echo $block->namespace_module() ?>" frontName="<?php echo $block->namespace_module() ?>">
+            <module name="<?php echo $block->namespace_module(false) ?>" before="Magento_Backend" />
         </route>
     </router>
 </config>

--- a/src/templates/src/etc/events.phtml
+++ b/src/templates/src/etc/events.phtml
@@ -2,6 +2,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="<?php echo $block->getData('event_name') ?>">
-        <observer name="<?php echo $block->namespace_module() ?>_<?php echo strtolower($block->getData('event_name')) ?>" instance="<?php echo $block->getData('namespace') ?>\<?php echo $block->getData('module') ?>\Observer\<?php echo $block->getData('class_name') ?>" />
+        <observer name="<?php echo $block->namespace_module() ?>_<?php echo strtolower($block->getData('event_name')) ?>" instance="<?php echo $block->NamespaceModule() ?>\Observer\<?php echo $block->getData('class_name') ?>" />
     </event>
 </config>

--- a/src/templates/src/etc/frontend/routes.phtml
+++ b/src/templates/src/etc/frontend/routes.phtml
@@ -2,8 +2,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="standard">
-        <route id="<?php echo strtolower($block->getData('namespace') .'_'. $block->getData('module')) ?>" frontName="<?php echo strtolower($block->getData('namespace') .'_'. $block->getData('module')) ?>">
-            <module name="<?php echo $block->getData('namespace') ?>_<?php echo $block->getData('module') ?>" />
+        <route id="<?php echo $block->namespace_module() ?>" frontName="<?php echo $block->namespace_module() ?>">
+            <module name="<?php echo $block->namespace_module(false) ?>" />
         </route>
     </router>
 </config>

--- a/src/templates/src/etc/module.phtml
+++ b/src/templates/src/etc/module.phtml
@@ -1,5 +1,5 @@
 <?php /** @var Brideo\Magento2Scaffolding\Block\File $block */ ?>
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="<?php echo $block->getData('namespace') ?>_<?php echo $block->getData('module') ?>" setup_version="<?php echo $block->getData('version') ?>"/>
+    <module name="<?php echo $block->namespace_module(false) ?>" setup_version="<?php echo $block->getData('version') ?>"/>
 </config>

--- a/src/templates/src/registration.phtml
+++ b/src/templates/src/registration.phtml
@@ -5,6 +5,6 @@
 
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::MODULE,
-    '<?php echo $block->getData('namespace') ?>_<?php echo $block->getData('module') ?>',
+    '<?php echo $block->namespace_module(false) ?>',
     __DIR__
 );

--- a/src/templates/src/view/adminhtml/layout/module_layout_index.phtml
+++ b/src/templates/src/view/adminhtml/layout/module_layout_index.phtml
@@ -1,43 +1,9 @@
 <?php
 /** @var Brideo\Magento2Scaffolding\Block\File $block */
-
-/**
- * Class AdminHelper
- *
- * @TODO: Move this monstrosity
- */
-class AdminHelper
-{
-
-    /**
-     * Dirty helper function.
-     *
-     * @param \Brideo\Magento2Scaffolding\Block\File $block
-     *
-     * @return string
-     */
-    static public function getName(Brideo\Magento2Scaffolding\Block\File $block)
-    {
-        return strtolower($block->getData('namespace') . '_' . $block->getData('module') . '_' . $block->getData('front_name') . '_' . $block->getData('action_name'));
-    }
-
-    /**
-     * Dirty helper function.
-     *
-     * @param \Brideo\Magento2Scaffolding\Block\File $block
-     *
-     * @return string
-     */
-    static public function getTemplate(Brideo\Magento2Scaffolding\Block\File $block)
-    {
-        return $block->getData('namespace') . '_' . $block->getData('module') . '::' . strtolower($block->getData('front_name') . '/' . $block->getData('action_name')) . '.phtml';
-    }
-}
-
 ?>
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceContainer name="content">
-        <block class="Magento\Backend\Block\Template" name="<?php echo AdminHelper::getName($block) ?>" template="<?php echo AdminHelper::getTemplate($block) ?>" />
+        <block class="Magento\Backend\Block\Template" name="<?php echo $block->namespace_module_frontname_action() ?>" template="<?php echo $block->template_name() ?>" />
     </referenceContainer>
 </page>

--- a/src/templates/src/view/frontend/layout/module_layout_index.phtml
+++ b/src/templates/src/view/frontend/layout/module_layout_index.phtml
@@ -1,43 +1,9 @@
 <?php
 /** @var Brideo\Magento2Scaffolding\Block\File $block */
-
-/**
- * Class FrontendHelper
- *
- * @TODO: Move this monstrosity
- */
-class FrontendHelper
-{
-
-    /**
-     * Dirty helper function.
-     *
-     * @param \Brideo\Magento2Scaffolding\Block\File $block
-     *
-     * @return string
-     */
-    static public function getName(Brideo\Magento2Scaffolding\Block\File $block)
-    {
-        return strtolower($block->getData('namespace') . '_' . $block->getData('module') . '_' . $block->getData('front_name') . '_' . $block->getData('action_name'));
-    }
-
-    /**
-     * Dirty helper function.
-     *
-     * @param \Brideo\Magento2Scaffolding\Block\File $block
-     *
-     * @return string
-     */
-    static public function getTemplate(Brideo\Magento2Scaffolding\Block\File $block)
-    {
-        return $block->getData('namespace') . '_' . $block->getData('module') . '::' . strtolower($block->getData('front_name') . '/' . $block->getData('action_name')) . '.phtml';
-    }
-}
-
 ?>
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <referenceContainer name="content">
-        <block class="Magento\Framework\View\Element\Template" name="<?php echo FrontendHelper::getName($block) ?>" template="<?php echo FrontendHelper::getTemplate($block) ?>" />
+        <block class="Magento\Framework\View\Element\Template" name="<?php echo $block->namespace_module_frontname_action() ?>" template="<?php echo $block->template_name() ?>" />
     </referenceContainer>
 </page>


### PR DESCRIPTION
Although we are offering methods which are not available for some templates
this is a better solution that repeating boilerplate logic throughout
each template.

This commit not only makes making righting new templates easier, but it
also removes the chances for typos.
